### PR TITLE
Fixes for readr 1.2.0

### DIFF
--- a/R/mudata.io.R
+++ b/R/mudata.io.R
@@ -559,7 +559,7 @@ mudata_parse_column <- function(x, type_str = NA_character_, ...) {
   if(inherits(x, parse_output_class(type_str))) {
     x
   } else {
-    as_parser(type_str)(x, ...)
+    as_parser(type_str)(as.character(x), ...)
   }
 }
 

--- a/R/types.R
+++ b/R/types.R
@@ -157,7 +157,7 @@ as_parser <- function(type_str) {
   
   # return a partial wrapper using type_obj$args
   function(x) {
-    do.call(parse_fun, c(list(x), type_obj$args))
+    do.call(parse_fun, c(list(quote(x)), type_obj$args))
   }
 }
 


### PR DESCRIPTION
The deparsing commit is just a quality of life improvement I noticed when debugging the test failure with readr 1.2.0.

readr 1.2.0 now errors when the parse functions are used with non-character input. This has always been unexpected input, but previously it would not be an error.

This change simply coerces the vectors to character before passing to the parse functions.

I plan to release readr 1.2.0 to CRAN soon, you will need to release mudata2 as well after it is accepted to avoid test failures on CRAN.