### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/R/mudata-io.R
+++ b/R/mudata-io.R
@@ -455,8 +455,7 @@ update_columns_table <- function(md, quiet = FALSE) {
   
   # join with columns to see if any types need to be updated
   generated_cols_joined <- md$columns %>%
-    dplyr::left_join(generated_cols, by = c("dataset", "table", "column"),
-                     prefix = c(".x", ".y"))
+    dplyr::left_join(generated_cols, by = c("dataset", "table", "column"))
   
   # check that type.x and type.y are the same, if type was already in the columns table
   if("type" %in% colnames(md$columns)) {
@@ -471,8 +470,7 @@ update_columns_table <- function(md, quiet = FALSE) {
     
     # overwrite the type column in md$columns, add new column data
     md$columns <- generated_cols %>%
-      dplyr::left_join(md$columns, by = c("dataset", "table", "column"),
-                       prefix = c(".x", ".y")) %>%
+      dplyr::left_join(md$columns, by = c("dataset", "table", "column")) %>%
       dplyr::mutate(type = type.x) %>%
       dplyr::select(-type.y, -type.x)
   } else {

--- a/R/mudata.R
+++ b/R/mudata.R
@@ -164,7 +164,7 @@ mudata <- function(data, locations=NULL, params=NULL, datasets=NULL, columns=NUL
               more_tbls)
   
   # coerce to tbls using dplyr
-  mdlist <- lapply(mdlist, dplyr::as.tbl)
+  mdlist <- lapply(mdlist, tibble::as_tibble)
   
   # create object using new_mudata
   md <- new_mudata(mdlist, x_columns = x_columns)

--- a/R/mudata.R
+++ b/R/mudata.R
@@ -406,7 +406,7 @@ as_mudata.list <- function(x, ...) {
     dplyr::group_by_all() %>%
     dplyr::tally() %>%
     dplyr::ungroup() %>%
-    dplyr::select(.data$n) %>%
+    dplyr::select("n") %>%
     dplyr::distinct()
   
   if(!identical(lengths[[1]], 1L)) {


### PR DESCRIPTION
In dplyr 1.1.0, `left_join()` will become now stricter in the arguments it accepts and will throw an error when supplied an unknown argument instead of ignoring them. In this case, you were supplying a `prefix` argument, presumably instead of `suffix`.

This PR fixes the error and also a couple of other warnings.

We plan to release dplyr on January 27. If possible, a pre-emptive fix release would be helpful to our release process. Thanks!